### PR TITLE
Now allows a flag indicating that a new auth token should not be gene…

### DIFF
--- a/Source/UI/Areas/Api/Controllers/UserSessionsController.cs
+++ b/Source/UI/Areas/Api/Controllers/UserSessionsController.cs
@@ -31,13 +31,22 @@ namespace UI.Areas.Api.Controllers
             {
                 return Request.CreateErrorResponse(HttpStatusCode.Unauthorized, "Invalid credentials provided.");
             }
-            var authToken = authTokenGenerator.GenerateAuthToken(user.Id);
+
             NewAuthTokenMessage newAuthTokenMessage = new NewAuthTokenMessage
             {
-                AuthenticationToken = authToken.AuthenticationTokenString,
                 AuthenticationTokenExpirationDateTime = user.AuthenticationTokenExpirationDate
             };
-            
+
+            if (credentialsMessage.PreserveExistingAuthenticationToken)
+            {
+                newAuthTokenMessage.AuthenticationToken = user.AuthenticationToken;
+            }
+            else
+            {
+                var newAuthToken = authTokenGenerator.GenerateAuthToken(user.Id);
+                newAuthTokenMessage.AuthenticationToken = newAuthToken.AuthenticationTokenString;
+            }
+
             return Request.CreateResponse(HttpStatusCode.OK, newAuthTokenMessage);
         }
     }

--- a/Source/UI/Areas/Api/Models/CredentialsMessage.cs
+++ b/Source/UI/Areas/Api/Models/CredentialsMessage.cs
@@ -8,5 +8,7 @@ namespace UI.Areas.Api.Models
         public string Password { get; set; }
         [Required]
         public string UserName { get; set; }
+
+        public bool PreserveExistingAuthenticationToken { get; set; }
     }
 }

--- a/Tests/UI.Tests/UnitTests/AreasTests/ApiTests/ControllersTests/UserSessionsControllerTests.cs
+++ b/Tests/UI.Tests/UnitTests/AreasTests/ApiTests/ControllersTests/UserSessionsControllerTests.cs
@@ -11,6 +11,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.Http.Controllers;
+using Shouldly;
 using UI.Areas.Api.Controllers;
 using UI.Areas.Api.Models;
 using UI.Transformations;
@@ -93,6 +94,38 @@ namespace UI.Tests.UnitTests.AreasTests.ApiTests.ControllersTests
             var newAuthTokenMessage = content.Value as NewAuthTokenMessage;
             Assert.That(newAuthTokenMessage.AuthenticationToken, Is.EqualTo(someNewAuthToken.AuthenticationTokenString));
             Assert.That(newAuthTokenMessage.AuthenticationTokenExpirationDateTime, Is.EqualTo(loggedInUser.AuthenticationTokenExpirationDate));
+        }
+
+        [Test]
+        public async Task ItUsesTheExistingAuthenticationTokenIfSpecified()
+        {
+            var credentialsMessage = new CredentialsMessage
+            {
+                UserName = "valid username",
+                Password = "valid corresponding password",
+                PreserveExistingAuthenticationToken = true
+            };
+
+            var loggedInUser = new ApplicationUser
+            {
+                Id = "some user id",
+                AuthenticationTokenExpirationDate = new DateTime(),
+                AuthenticationToken = "some existinig auth token"
+            };
+
+            autoMocker.Get<ApplicationUserManager>().Expect(mock => mock.FindAsync(
+                                        Arg<string>.Matches(userName => userName == credentialsMessage.UserName),
+                                        Arg<string>.Matches(password => password == credentialsMessage.Password)))
+                    .Return(Task.FromResult(loggedInUser));
+
+
+            var actualResponse = await autoMocker.ClassUnderTest.Login(credentialsMessage);
+
+            autoMocker.Get<IAuthTokenGenerator>().AssertWasNotCalled(mock => mock.GenerateAuthToken(Arg<string>.Is.Anything));
+            Assert.That(actualResponse.Content, Is.TypeOf(typeof(ObjectContent<NewAuthTokenMessage>)));
+            var content = actualResponse.Content as ObjectContent<NewAuthTokenMessage>;
+            var newAuthTokenMessage = content.Value as NewAuthTokenMessage;
+            newAuthTokenMessage.AuthenticationToken.ShouldBe(loggedInUser.AuthenticationToken);
         }
     }
 }


### PR DESCRIPTION
…rated when logging in.

This is useful when there are multiple devices signed in at once.