### PR TITLE
Adjust Forgot Password page styling to match Login/Register page styling

### DIFF
--- a/Source/UI/Views/Account/ForgotPassword.cshtml
+++ b/Source/UI/Views/Account/ForgotPassword.cshtml
@@ -3,28 +3,41 @@
     ViewBag.Title = "Forgot your password?";
 }
 
-<h2 class="body-content">@ViewBag.Title</h2>
+<div class="container body-content">
+	<h2 class="page-header">@ViewBag.Title</h2>
+	<hr />
 
-@using (Html.BeginForm("ForgotPassword", "Account", FormMethod.Post, new { @class = "form-horizontal", role = "form" }))
-{
-	<div class="body-content">
-		@Html.AntiForgeryToken()
-		<h4>Enter your email.</h4>
-		<hr />
-		@Html.ValidationSummary("", new { @class = "text-danger" })
-		<div class="form-group">
-			@Html.LabelFor(m => m.Email, new { @class = "col-md-2 control-label" })
-			<div class="col-md-10">
-				@Html.TextBoxFor(m => m.Email, new { @class = "form-control" })
-			</div>
-		</div>
-		<div class="form-group">
-			<div class="col-md-offset-2 col-md-10">
-				<input type="submit" class="btn btn-default" value="Email Link" />
+	<div class="row">
+		<div class="col-md-12">
+			<div class="panel panel-primary">
+				<div class="panel-heading">
+					<h4>Enter your email.</h4>
+				</div>i
+				<div class="panel-body">
+					<section>
+						@using (Html.BeginForm("ForgotPassword", "Account", FormMethod.Post, new { @class = "form-horizontal", role = "form" }))
+						{
+							@Html.AntiForgeryToken()
+							@Html.ValidationSummary("", new { @class = "text-danger" })
+							<div class="form-group">
+								@Html.LabelFor(m => m.Email, new { @class = "col-xs-5 control-label" })
+								<div class="col-xs-7">
+									@Html.TextBoxFor(m => m.Email, new { @class = "form-control" })
+								</div>
+							</div>
+							<div class="form-group">
+								<div class="col-sm-offset-1 col-sm-11">
+									<input type="submit" class="btn btn-primary" value="Email Link" />
+								</div>
+							</div>
+						}
+					</section>
+				</div>
 			</div>
 		</div>
 	</div>
-}
+
+</div>
 
 @section Scripts {
     @Scripts.Render("~/bundles/jqueryval")


### PR DESCRIPTION
This change generates HTML that looks like the snippet from [my comment](https://github.com/NemeStats/NemeStats/issues/506#issuecomment-250369231) on the issue.

I haven't had a chance to test this quite yet. I'm more than willing to set up my Windows desktop for testing tomorrow evening.

Closes #506 