### PR TITLE
Compare achievement dates against the current time

### DIFF
--- a/Source/UI/Views/Achievement/Details.cshtml
+++ b/Source/UI/Views/Achievement/Details.cshtml
@@ -57,7 +57,7 @@ else
                             </span>
                         </span>
                     </li>
-                    @if (Model.DateCreated.HasValue)
+                    @if (Model.DateCreated.HasValue && Model.DateCreated <= DateTime.UtcNow)
                     {
                     <li class="list-group-item">Unlocked at: @Model.DateCreated.Value.ToShortDateString()</li>
                     }


### PR DESCRIPTION
This avoids an issue where we could show a future date as the unlock/updated date

Fixes #498 