### PR TITLE
Only show the Tweet button if the user can edit the played game

### DIFF
--- a/Source/UI/Views/PlayedGame/Details.cshtml
+++ b/Source/UI/Views/PlayedGame/Details.cshtml
@@ -2,6 +2,7 @@
 @using BusinessLogic.Models.PlayedGames
 @using UI.HtmlHelpers
 @using UI.Models.Players
+
 @{
     string title = @Model.GameDefinitionName + " - " + Model.DatePlayed.ToShortDateString();
     ViewBag.Title = title + " - " + Model.GamingGroupName;
@@ -50,8 +51,12 @@
     {
         <span class="gameResult-teamWin"> - TEAM WIN</span>
     }
-    <a href="https://twitter.com/share" class="twitter-share-button" data-text="Check out this game I played on &#64;nemestats :" data-size="large" data-related="nemestats" data-count="none" data-hashtags="boardgames" data-dnt="true" title="Tweet a link to this game">Tweet</a>
-    <script>!function (d, s, id) { var js, fjs = d.getElementsByTagName(s)[0], p = /^http:/.test(d.location) ? 'http' : 'https'; if (!d.getElementById(id)) { js = d.createElement(s); js.id = id; js.src = p + '://platform.twitter.com/widgets.js'; fjs.parentNode.insertBefore(js, fjs); } }(document, 'script', 'twitter-wjs');</script>
+
+    @if (Model.UserCanEdit)
+    {
+        <a href="https://twitter.com/share" class="twitter-share-button" data-text="Check out this game I played on &#64;nemestats :" data-size="large" data-related="nemestats" data-count="none" data-hashtags="boardgames" data-dnt="true" title="Tweet a link to this game">Tweet</a>
+        <script>!function (d, s, id) { var js, fjs = d.getElementsByTagName(s)[0], p = /^http:/.test(d.location) ? 'http' : 'https'; if (!d.getElementById(id)) { js = d.createElement(s); js.id = id; js.src = p + '://platform.twitter.com/widgets.js'; fjs.parentNode.insertBefore(js, fjs); } }(document, 'script', 'twitter-wjs');</script>
+    }
 </h2>
 
 <div class="row">


### PR DESCRIPTION
A user can edit the played game if they are logged in and their
current gaming group is the same as the gaming group from the played
game.

This change makes the Tweet button also require the above conditions,
so the user must have the played game's group as their current active
gaming group.

This fix may change depending on feedback from a current email chain with @jakejgordon.
Relevant part of the email:
```
I'm wondering if I can just use UserCanEdit to determine if a tweet can be sent out. It feels like a really
weird design to make someone have to switch their current gaming group just to send out a tweet, but it
would follow the pattern that has already been set. Another option might be to edit the
PlayedGameDetailsViewModelBuilder to add a UserInGroup that checks if the user is in the group (with a
loop like the one above). That would avoid needing to switch groups to send the tweet.
```

Fixes #153 