### PR TITLE
626 api enhancements

### DIFF
--- a/Source/BoardGameGeekApiClient/BoardGameGeekApiClient.csproj
+++ b/Source/BoardGameGeekApiClient/BoardGameGeekApiClient.csproj
@@ -51,9 +51,8 @@
       <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="RollbarSharp, Version=0.3.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\RollbarSharp.0.3.5.0\lib\net40\RollbarSharp.dll</HintPath>

--- a/Source/BoardGameGeekApiClient/app.config
+++ b/Source/BoardGameGeekApiClient/app.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Source/BoardGameGeekApiClient/packages.config
+++ b/Source/BoardGameGeekApiClient/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Bcl" version="1.1.8" targetFramework="net452" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="RollbarSharp" version="0.3.5.0" targetFramework="net452" />
   <package id="X.PagedList" version="1.24.1.320" targetFramework="net452" />
 </packages>

--- a/Source/BusinessLogic/App.config
+++ b/Source/BusinessLogic/App.config
@@ -27,7 +27,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Source/BusinessLogic/BusinessLogic.csproj
+++ b/Source/BusinessLogic/BusinessLogic.csproj
@@ -108,9 +108,8 @@
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.1\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -120,17 +119,11 @@
       <HintPath>..\..\packages\RollbarSharp.0.3.5.0\lib\net40\RollbarSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SendGrid, Version=6.3.0.0, Culture=neutral, PublicKeyToken=4f047e93159395ca, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Sendgrid.6.3.0\lib\SendGrid.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SendGrid, Version=9.8.0.0, Culture=neutral, PublicKeyToken=4f047e93159395ca, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Sendgrid.9.9.0\lib\net452\SendGrid.dll</HintPath>
     </Reference>
-    <Reference Include="SendGrid.SmtpApi, Version=1.3.1.0, Culture=neutral, PublicKeyToken=2ae73662c35d80e4, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SendGrid.SmtpApi.1.3.1\lib\net40\SendGrid.SmtpApi.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="SendGridMail, Version=6.3.0.0, Culture=neutral, PublicKeyToken=4f047e93159395ca, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Sendgrid.6.3.0\lib\SendGridMail.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SendGrid.SmtpApi, Version=1.3.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SendGrid.SmtpApi.1.3.3\lib\SendGrid.SmtpApi.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap, Version=4.4.2.472, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\StructureMap.4.4.2\lib\net45\StructureMap.dll</HintPath>

--- a/Source/BusinessLogic/BusinessLogic.csproj
+++ b/Source/BusinessLogic/BusinessLogic.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Exceptions\InvalidSourceException.cs" />
     <Compile Include="Exceptions\PlayerAlreadyExistsException.cs" />
     <Compile Include="Exceptions\PlayerNotInGamingGroupException.cs" />
+    <Compile Include="Exceptions\PlayerWithThisEmailAlreadyExistsException.cs" />
     <Compile Include="Exceptions\UnauthorizedEntityAccessException.cs" />
     <Compile Include="Exceptions\UserHasNoGamingGroupException.cs" />
     <Compile Include="Export\ExcelGenerator.cs" />

--- a/Source/BusinessLogic/Exceptions/ApiFriendlyException.cs
+++ b/Source/BusinessLogic/Exceptions/ApiFriendlyException.cs
@@ -10,5 +10,10 @@ namespace BusinessLogic.Exceptions
         {
             StatusCode = statusCode;
         }
+
+        /// <summary>
+        /// Used to further distinguish between multiple possible instances of the same HTTP Status code
+        /// </summary>
+        public int? ErrorSubCode { get; set; }
     }
 }

--- a/Source/BusinessLogic/Exceptions/PlayerAlreadyExistsException.cs
+++ b/Source/BusinessLogic/Exceptions/PlayerAlreadyExistsException.cs
@@ -28,7 +28,6 @@ namespace BusinessLogic.Exceptions
             : base(string.Format(EXCEPTION_MESSAGE, playerName, existingPlayerId))
         {
             ExistingPlayerId = existingPlayerId;
-            
         }
     }
 }

--- a/Source/BusinessLogic/Exceptions/PlayerWithThisEmailAlreadyExistsException.cs
+++ b/Source/BusinessLogic/Exceptions/PlayerWithThisEmailAlreadyExistsException.cs
@@ -1,0 +1,13 @@
+﻿using System.Net;
+
+namespace BusinessLogic.Exceptions
+{
+    public class PlayerWithThisEmailAlreadyExistsException : ApiFriendlyException
+    {
+        internal const string EXCEPTION_MESSAGE_FORMAT = "A User with email address '{0}' is already associated with the Player '{1}'. The existing playerId is '{2}'.";
+        public PlayerWithThisEmailAlreadyExistsException(string emailAddress, string playerName, int playerId) 
+            : base(string.Format(EXCEPTION_MESSAGE_FORMAT, emailAddress, playerName, playerId), HttpStatusCode.Conflict)
+        {
+        }
+    }
+}

--- a/Source/BusinessLogic/Logic/Email/EmailService.cs
+++ b/Source/BusinessLogic/Logic/Email/EmailService.cs
@@ -18,8 +18,6 @@
 using Microsoft.AspNet.Identity;
 using SendGrid;
 using System.Configuration;
-using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using SendGrid.Helpers.Mail;
 
@@ -29,11 +27,6 @@ namespace BusinessLogic.Logic.Email
     {
         public Task SendAsync(IdentityMessage message)
         {
-            return configSendGridasync(message);
-        }
-
-        private Task configSendGridasync(IdentityMessage message)
-        {
             var myMessage = new SendGridMessage();
             myMessage.AddTo(message.Destination);
             myMessage.From = new EmailAddress("nemestats@gmail.com", "NemeStats");
@@ -41,16 +34,9 @@ namespace BusinessLogic.Logic.Email
             myMessage.HtmlContent = message.Body;
             myMessage.PlainTextContent = message.Body;
 
-            //TODO REMOVE THIS?
-            //var credentials = new NetworkCredential(
-            //           ConfigurationManager.AppSettings["emailServiceUserName"],
-            //           ConfigurationManager.AppSettings["emailServicePassword"]
-            //           );
-
             var apiKey = ConfigurationManager.AppSettings["sendgridApiKey"];
             var sendGridClient = new SendGridClient(apiKey);
 
-            // Send the email.
             return sendGridClient.SendEmailAsync(myMessage);
         }
     }

--- a/Source/BusinessLogic/Logic/Email/EmailService.cs
+++ b/Source/BusinessLogic/Logic/Email/EmailService.cs
@@ -21,6 +21,7 @@ using System.Configuration;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using SendGrid.Helpers.Mail;
 
 namespace BusinessLogic.Logic.Email
 {
@@ -35,22 +36,22 @@ namespace BusinessLogic.Logic.Email
         {
             var myMessage = new SendGridMessage();
             myMessage.AddTo(message.Destination);
-            myMessage.From = new System.Net.Mail.MailAddress(
-                                "nemestats@gmail.com", "NemeStats");
+            myMessage.From = new EmailAddress("nemestats@gmail.com", "NemeStats");
             myMessage.Subject = message.Subject;
-            myMessage.Text = message.Body;
-            myMessage.Html = message.Body;
+            myMessage.HtmlContent = message.Body;
+            myMessage.PlainTextContent = message.Body;
 
-            var credentials = new NetworkCredential(
-                       ConfigurationManager.AppSettings["emailServiceUserName"],
-                       ConfigurationManager.AppSettings["emailServicePassword"]
-                       );
+            //TODO REMOVE THIS?
+            //var credentials = new NetworkCredential(
+            //           ConfigurationManager.AppSettings["emailServiceUserName"],
+            //           ConfigurationManager.AppSettings["emailServicePassword"]
+            //           );
 
-            // Create a Web transport for sending email.
-            var transportWeb = new Web(credentials);
+            var apiKey = ConfigurationManager.AppSettings["sendgridApiKey"];
+            var sendGridClient = new SendGridClient(apiKey);
 
             // Send the email.
-            return transportWeb.DeliverAsync(myMessage);
+            return sendGridClient.SendEmailAsync(myMessage);
         }
     }
 }

--- a/Source/BusinessLogic/Logic/GamingGroups/GamingGroupInfoForUser.cs
+++ b/Source/BusinessLogic/Logic/GamingGroups/GamingGroupInfoForUser.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using BusinessLogic.Models;
+﻿using BusinessLogic.Models;
 
 namespace BusinessLogic.Logic.GamingGroups
 {

--- a/Source/BusinessLogic/Logic/Players/PlayerInviter.cs
+++ b/Source/BusinessLogic/Logic/Players/PlayerInviter.cs
@@ -31,15 +31,15 @@ namespace BusinessLogic.Logic.Players
     {
         internal const string APP_SETTING_URL_ROOT = "urlRoot";
 
-        private readonly IDataContext dataContext;
-        private readonly IIdentityMessageService emailService;
-        private readonly IConfigurationManager configurationManager;
+        private readonly IDataContext _dataContext;
+        private readonly IIdentityMessageService _emailService;
+        private readonly IConfigurationManager _configurationManager;
 
         public PlayerInviter(IDataContext dataContext, IIdentityMessageService emailService, IConfigurationManager configurationManager)
         {
-            this.dataContext = dataContext;
-            this.emailService = emailService;
-            this.configurationManager = configurationManager;
+            _dataContext = dataContext;
+            _emailService = emailService;
+            _configurationManager = configurationManager;
         }
 
         public void InvitePlayer(PlayerInvitation playerInvitation, ApplicationUser currentUser)
@@ -48,9 +48,9 @@ namespace BusinessLogic.Logic.Players
             {
                 throw new UserHasNoGamingGroupException(currentUser.Id);
             }
-            GamingGroup gamingGroup = dataContext.FindById<GamingGroup>(currentUser.CurrentGamingGroupId);
+            GamingGroup gamingGroup = _dataContext.FindById<GamingGroup>(currentUser.CurrentGamingGroupId);
 
-            string existingUserId = (from ApplicationUser user in dataContext.GetQueryable<ApplicationUser>()
+            string existingUserId = (from ApplicationUser user in _dataContext.GetQueryable<ApplicationUser>()
                                      where user.Email == playerInvitation.InvitedPlayerEmail
                                      select user.Id).FirstOrDefault();       
             
@@ -64,11 +64,11 @@ namespace BusinessLogic.Logic.Players
                 RegisteredUserId = existingUserId
             };
 
-            GamingGroupInvitation savedGamingGroupInvitation = dataContext.Save(gamingGroupInvitation, currentUser);
+            GamingGroupInvitation savedGamingGroupInvitation = _dataContext.Save(gamingGroupInvitation, currentUser);
             //commit so we can get the Id back
-            dataContext.CommitAllChanges();
+            _dataContext.CommitAllChanges();
 
-            string urlRoot = configurationManager.AppSettings[APP_SETTING_URL_ROOT];
+            string urlRoot = _configurationManager.AppSettings[APP_SETTING_URL_ROOT];
 
             var customMessage = string.Empty;
             if (!string.IsNullOrWhiteSpace(playerInvitation.CustomEmailMessage))
@@ -90,7 +90,7 @@ namespace BusinessLogic.Logic.Players
                 Subject = playerInvitation.EmailSubject
             };
             
-            emailService.SendAsync(message);
+            _emailService.SendAsync(message);
         }
     }
 }

--- a/Source/BusinessLogic/Logic/Players/PlayerInviter.cs
+++ b/Source/BusinessLogic/Logic/Players/PlayerInviter.cs
@@ -30,9 +30,6 @@ namespace BusinessLogic.Logic.Players
     public class PlayerInviter : IPlayerInviter
     {
         internal const string APP_SETTING_URL_ROOT = "urlRoot";
-        internal const string EMAIL_MESSAGE_INVITE_PLAYER = "Hi There! You've been invited by {0} to join the \"{1}\" Gaming Group on {2}. {5}"
-                                  + "{0} says: {3} {5} "
-                                  + "To join this Gaming Group click on this link: {2}/Account/ConsumeInvitation/{4}";
 
         private readonly IDataContext dataContext;
         private readonly IIdentityMessageService emailService;
@@ -73,13 +70,19 @@ namespace BusinessLogic.Logic.Players
 
             string urlRoot = configurationManager.AppSettings[APP_SETTING_URL_ROOT];
 
-            string messageBody = string.Format(PlayerInviter.EMAIL_MESSAGE_INVITE_PLAYER,
-                                                currentUser.UserName,
-                                                gamingGroup.Name,
-                                                urlRoot,
-                                                playerInvitation.CustomEmailMessage,
-                                                savedGamingGroupInvitation.Id,
-                                                "<br/><br/>");
+            var customMessage = string.Empty;
+            if (!string.IsNullOrWhiteSpace(playerInvitation.CustomEmailMessage))
+            {
+                customMessage = $"{currentUser.UserName} says: {playerInvitation.CustomEmailMessage}";
+            }
+
+            var messageBody = $@"Well hello there! You've been invited by '{currentUser.UserName}' to join the NemeStats Gaming Group called '{gamingGroup.Name}'! 
+                To join this Gaming Group, click on the following link: {urlRoot}/Account/ConsumeInvitation/{savedGamingGroupInvitation.Id} <br/><br/>
+
+                {customMessage} <br/><br/>
+
+                If you believe you've received this in error just disregard the email.";
+
             var message = new IdentityMessage
             {
                 Body = messageBody,

--- a/Source/BusinessLogic/Logic/Players/PlayerInviter.cs
+++ b/Source/BusinessLogic/Logic/Players/PlayerInviter.cs
@@ -30,7 +30,7 @@ namespace BusinessLogic.Logic.Players
     public class PlayerInviter : IPlayerInviter
     {
         internal const string APP_SETTING_URL_ROOT = "urlRoot";
-        internal const string EMAIL_MESSAGE_INVITE_PLAYER = "Hi There! You've been invited by {0} to join the \"{1}\" gaming group on {2}. {5}"
+        internal const string EMAIL_MESSAGE_INVITE_PLAYER = "Hi There! You've been invited by {0} to join the \"{1}\" Gaming Group on {2}. {5}"
                                   + "{0} says: {3} {5} "
                                   + "To join this Gaming Group click on this link: {2}/Account/ConsumeInvitation/{4}";
 
@@ -67,7 +67,7 @@ namespace BusinessLogic.Logic.Players
                 RegisteredUserId = existingUserId
             };
 
-            GamingGroupInvitation savedGamingGroupInvitation = dataContext.Save<GamingGroupInvitation>(gamingGroupInvitation, currentUser);
+            GamingGroupInvitation savedGamingGroupInvitation = dataContext.Save(gamingGroupInvitation, currentUser);
             //commit so we can get the Id back
             dataContext.CommitAllChanges();
 

--- a/Source/BusinessLogic/Logic/Players/PlayerSaver.cs
+++ b/Source/BusinessLogic/Logic/Players/PlayerSaver.cs
@@ -67,6 +67,16 @@ namespace BusinessLogic.Logic.Players
 
             newPlayer = _dataContext.Save(newPlayer, applicationUser);
 
+            if (!string.IsNullOrWhiteSpace(createPlayerRequest.PlayerEmailAddress))
+            {
+                var playerInvitation = new PlayerInvitation
+                {
+                    EmailSubject = $"NemeStats Invitation from {applicationUser.UserName}",
+                    InvitedPlayerEmail = createPlayerRequest.PlayerEmailAddress,
+                    InvitedPlayerId = newPlayer.Id
+                };
+                _playerInviter.InvitePlayer(playerInvitation, applicationUser);
+            }
 
             _dataContext.CommitAllChanges();
 

--- a/Source/BusinessLogic/Models/Players/CreatePlayerRequest.cs
+++ b/Source/BusinessLogic/Models/Players/CreatePlayerRequest.cs
@@ -4,5 +4,6 @@
     {
         public string Name { get; set; }
         public int? GamingGroupId { get; set; }
+        public string PlayerEmailAddress { get; set; }
     }
 }

--- a/Source/BusinessLogic/packages.config
+++ b/Source/BusinessLogic/packages.config
@@ -17,14 +17,15 @@
   <package id="Microsoft.Owin.Security.Cookies" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security.OAuth" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="RollbarSharp" version="0.3.5.0" targetFramework="net452" />
-  <package id="Sendgrid" version="6.3.0" targetFramework="net45" />
-  <package id="SendGrid.SmtpApi" version="1.3.1" targetFramework="net45" />
+  <package id="Sendgrid" version="9.9.0" targetFramework="net452" />
+  <package id="SendGrid.SmtpApi" version="1.3.3" targetFramework="net452" />
   <package id="StructureMap" version="4.4.2" targetFramework="net452" />
   <package id="structuremap.web" version="4.0.0.315" targetFramework="net452" />
   <package id="System.Configuration.Abstractions" version="2.0.2.26" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.0.0" targetFramework="net452" />
   <package id="UniversalAnalyticsMeasurementProtocolWrapper" version="1.4.4" targetFramework="net452" />
   <package id="X.PagedList" version="1.24.1.320" targetFramework="net452" />
   <package id="xsitemap" version="1.5.0.100" targetFramework="net452" />

--- a/Source/NemeStats.Hubs/NemeStats.Hubs.csproj
+++ b/Source/NemeStats.Hubs/NemeStats.Hubs.csproj
@@ -42,9 +42,8 @@
       <HintPath>..\..\packages\Microsoft.Owin.Security.3.0.1\lib\net45\Microsoft.Owin.Security.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/Source/NemeStats.Hubs/app.config
+++ b/Source/NemeStats.Hubs/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Source/NemeStats.Hubs/packages.config
+++ b/Source/NemeStats.Hubs/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.AspNet.SignalR.Core" version="2.2.0" targetFramework="net452" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
 </packages>

--- a/Source/NemeStats.IoC/NemeStats.IoC.csproj
+++ b/Source/NemeStats.IoC/NemeStats.IoC.csproj
@@ -52,9 +52,8 @@
       <HintPath>..\..\packages\Microsoft.Owin.Security.3.0.1\lib\net45\Microsoft.Owin.Security.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/Source/NemeStats.IoC/app.config
+++ b/Source/NemeStats.IoC/app.config
@@ -24,7 +24,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Source/NemeStats.IoC/packages.config
+++ b/Source/NemeStats.IoC/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.1" targetFramework="net452" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="RollbarSharp" version="0.3.5.0" targetFramework="net452" />
   <package id="StructureMap" version="4.4.2" targetFramework="net452" />

--- a/Source/NemeStats.ScheduledJobs/App.config
+++ b/Source/NemeStats.ScheduledJobs/App.config
@@ -18,7 +18,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Source/NemeStats.ScheduledJobs/NemeStats.ScheduledJobs.csproj
+++ b/Source/NemeStats.ScheduledJobs/NemeStats.ScheduledJobs.csproj
@@ -102,9 +102,8 @@
       <HintPath>..\packages\ncrontab.2.0.0\lib\net20\NCrontab.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/Source/NemeStats.ScheduledJobs/packages.config
+++ b/Source/NemeStats.ScheduledJobs/packages.config
@@ -14,7 +14,7 @@
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.12" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="ncrontab" version="2.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="StructureMap" version="4.4.2" targetFramework="net452" />
   <package id="System.Configuration.Abstractions" version="2.0.2.26" targetFramework="net45" />

--- a/Source/UI/Areas/Api/Controllers/PlayersController.cs
+++ b/Source/UI/Areas/Api/Controllers/PlayersController.cs
@@ -1,5 +1,4 @@
 ﻿using BusinessLogic.Logic.Players;
-using BusinessLogic.Models;
 using BusinessLogic.Models.Players;
 using System.Linq;
 using System.Net;
@@ -13,13 +12,13 @@ namespace UI.Areas.Api.Controllers
 {
     public class PlayersController : ApiControllerBase
     {
-        private readonly IPlayerSaver playerSaver;
-        private readonly IPlayerRetriever playerRetriever;
+        private readonly IPlayerSaver _playerSaver;
+        private readonly IPlayerRetriever _playerRetriever;
 
         public PlayersController(IPlayerSaver playerSaver, IPlayerRetriever playerRetriever)
         {
-            this.playerSaver = playerSaver;
-            this.playerRetriever = playerRetriever;
+            _playerSaver = playerSaver;
+            _playerRetriever = playerRetriever;
         }
 
         [ApiModelValidation]
@@ -36,7 +35,7 @@ namespace UI.Areas.Api.Controllers
         [HttpGet]
         public virtual HttpResponseMessage GetPlayers([FromUri] int gamingGroupId)
         {
-            var results = playerRetriever.GetAllPlayers(gamingGroupId);
+            var results = _playerRetriever.GetAllPlayers(gamingGroupId);
 
             var playerSearchResultsMessage = new PlayersSearchResultsMessage
             {
@@ -74,7 +73,7 @@ namespace UI.Areas.Api.Controllers
                 GamingGroupId = newPlayerMessage.GamingGroupId
             };
 
-            var actualNewlyCreatedPlayer = playerSaver.CreatePlayer(requestedPlayer, CurrentUser);
+            var actualNewlyCreatedPlayer = _playerSaver.CreatePlayer(requestedPlayer, CurrentUser);
 
             var newlyCreatedPlayerMessage = new NewlyCreatedPlayerMessage
             {
@@ -113,7 +112,7 @@ namespace UI.Areas.Api.Controllers
                 Name = updatePlayerMessage.PlayerName
             };
 
-            playerSaver.UpdatePlayer(requestedPlayer, CurrentUser);
+            _playerSaver.UpdatePlayer(requestedPlayer, CurrentUser);
 
             return Request.CreateResponse(HttpStatusCode.NoContent);
         }

--- a/Source/UI/Areas/Api/Controllers/PlayersController.cs
+++ b/Source/UI/Areas/Api/Controllers/PlayersController.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Web.Http;
+using BusinessLogic.Exceptions;
+using BusinessLogic.Models;
 using UI.Areas.Api.Models;
 using UI.Attributes;
 using VersionedRestApi;
@@ -74,12 +76,26 @@ namespace UI.Areas.Api.Controllers
                 PlayerEmailAddress = newPlayerMessage.PlayerEmailAddress
             };
 
-            var actualNewlyCreatedPlayer = _playerSaver.CreatePlayer(requestedPlayer, CurrentUser);
+            Player newPlayer;
+            try
+            {
+                newPlayer = _playerSaver.CreatePlayer(requestedPlayer, CurrentUser);
+            }
+            catch (PlayerAlreadyExistsException exception)
+            {
+                exception.ErrorSubCode = 1;
+                throw;
+            }
+            catch (PlayerWithThisEmailAlreadyExistsException exception)
+            {
+                exception.ErrorSubCode = 2;
+                throw;
+            }
 
             var newlyCreatedPlayerMessage = new NewlyCreatedPlayerMessage
             {
-                PlayerId = actualNewlyCreatedPlayer.Id,
-                GamingGroupId = actualNewlyCreatedPlayer.GamingGroupId
+                PlayerId = newPlayer.Id,
+                GamingGroupId = newPlayer.GamingGroupId
             };
 
             return Request.CreateResponse(HttpStatusCode.OK, newlyCreatedPlayerMessage);

--- a/Source/UI/Areas/Api/Controllers/PlayersController.cs
+++ b/Source/UI/Areas/Api/Controllers/PlayersController.cs
@@ -70,7 +70,8 @@ namespace UI.Areas.Api.Controllers
             var requestedPlayer = new CreatePlayerRequest
             {
                 Name = newPlayerMessage.PlayerName,
-                GamingGroupId = newPlayerMessage.GamingGroupId
+                GamingGroupId = newPlayerMessage.GamingGroupId,
+                PlayerEmailAddress = newPlayerMessage.PlayerEmailAddress
             };
 
             var actualNewlyCreatedPlayer = _playerSaver.CreatePlayer(requestedPlayer, CurrentUser);

--- a/Source/UI/Areas/Api/Controllers/UsersController.cs
+++ b/Source/UI/Areas/Api/Controllers/UsersController.cs
@@ -9,24 +9,23 @@ using BusinessLogic.Logic.Users;
 using BusinessLogic.Models.User;
 using UI.Areas.Api.Models;
 using UI.Attributes;
-using UI.Transformations;
 using VersionedRestApi;
 
 namespace UI.Areas.Api.Controllers
 {
     public class UsersController : ApiControllerBase
     {
-        private readonly IUserRegisterer userRegisterer;
-        private readonly IAuthTokenGenerator authTokenGenerator;
-        private readonly IUserRetriever userRetriever;
-        private readonly ITransformer transformer;
+        private readonly IUserRegisterer _userRegisterer;
+        private readonly IAuthTokenGenerator _authTokenGenerator;
+        private readonly IUserRetriever _userRetriever;
+        private readonly ITransformer _transformer;
 
         public UsersController(IUserRegisterer userRegisterer, IAuthTokenGenerator authTokenGenerator, IUserRetriever userRetriever, ITransformer transformer)
         {
-            this.userRegisterer = userRegisterer;
-            this.authTokenGenerator = authTokenGenerator;
-            this.userRetriever = userRetriever;
-            this.transformer = transformer;
+            _userRegisterer = userRegisterer;
+            _authTokenGenerator = authTokenGenerator;
+            _userRetriever = userRetriever;
+            _transformer = transformer;
         }
 
         [ApiRoute("Users/")]
@@ -35,11 +34,11 @@ namespace UI.Areas.Api.Controllers
         {
             var newUser = Mapper.Map<NewUserMessage, NewUser>(newUserMessage);
 
-		    var registerNewUserResult = await this.userRegisterer.RegisterUser(newUser);
+		    var registerNewUserResult = await _userRegisterer.RegisterUser(newUser);
 
             if (registerNewUserResult.Result.Succeeded)
             {
-                var authToken = authTokenGenerator.GenerateAuthToken(registerNewUserResult.NewlyRegisteredUser.UserId, newUserMessage.UniqueDeviceId);
+                var authToken = _authTokenGenerator.GenerateAuthToken(registerNewUserResult.NewlyRegisteredUser.UserId, newUserMessage.UniqueDeviceId);
                 var newlyRegisteredUserMessage = Mapper.Map<NewlyRegisteredUser, NewlyRegisteredUserMessage>(registerNewUserResult.NewlyRegisteredUser);
                 newlyRegisteredUserMessage.AuthenticationToken = authToken.AuthenticationTokenString;
                 newlyRegisteredUserMessage.AuthenticationTokenExpirationDateTime =
@@ -55,8 +54,8 @@ namespace UI.Areas.Api.Controllers
         [ApiAuthentication]
         public virtual HttpResponseMessage GetUserInformation(string userId)
         {
-            var userInformation = userRetriever.RetrieveUserInformation(CurrentUser);
-            var userInformationMessage = this.transformer.Transform<UserInformationMessage>(userInformation);
+            var userInformation = _userRetriever.RetrieveUserInformation(CurrentUser);
+            var userInformationMessage = _transformer.Transform<UserInformationMessage>(userInformation);
             return Request.CreateResponse(HttpStatusCode.OK, userInformationMessage);
         }
     }

--- a/Source/UI/Areas/Api/Models/GamingGroupInfoForUserMessage.cs
+++ b/Source/UI/Areas/Api/Models/GamingGroupInfoForUserMessage.cs
@@ -8,5 +8,6 @@ namespace UI.Areas.Api.Models
         public string GamingGroupName { get; set; }
         public string GamingGroupPublicUrl { get; set; }
         public string GamingGroupPublicDescription { get; set; }
+        public bool Active { get; set; }
     }
 }

--- a/Source/UI/Areas/Api/Models/GenericErrorMessage.cs
+++ b/Source/UI/Areas/Api/Models/GenericErrorMessage.cs
@@ -4,11 +4,13 @@ namespace UI.Areas.Api.Models
 {
     public class GenericErrorMessage
     {
-        public GenericErrorMessage(string errorMessage)
+        public GenericErrorMessage(string errorMessage, int? errorSubCode = null)
         {
             Message = errorMessage;
+            ErrorSubCode = errorSubCode;
         }
 
-        public string Message { get; private set; }
+        public string Message { get; }
+        public int? ErrorSubCode { get; }
     }
 }

--- a/Source/UI/Areas/Api/Models/NewPlayerMessage.cs
+++ b/Source/UI/Areas/Api/Models/NewPlayerMessage.cs
@@ -8,5 +8,6 @@ namespace UI.Areas.Api.Models
         public string PlayerName { get; set; }
 
         public int? GamingGroupId { get; set; }
+        public string PlayerEmailAddress { get; set; }
     }
 }

--- a/Source/UI/Attributes/ApiExceptionFilter.cs
+++ b/Source/UI/Attributes/ApiExceptionFilter.cs
@@ -13,7 +13,7 @@ namespace UI.Attributes
             var exception = context.Exception as ApiFriendlyException;
             if (exception != null)
             {
-                context.Response = context.Request.CreateResponse(exception.StatusCode, new GenericErrorMessage(exception.Message));
+                context.Response = context.Request.CreateResponse(exception.StatusCode, new GenericErrorMessage(exception.Message, exception.ErrorSubCode));
             }else
             {
                 context.Response = context.Request.CreateResponse(HttpStatusCode.InternalServerError, 

--- a/Source/UI/Controllers/PlayerController.cs
+++ b/Source/UI/Controllers/PlayerController.cs
@@ -183,7 +183,7 @@ namespace UI.Controllers
 
             playerInviter.InvitePlayer(playerInvitation, currentUser);
 
-            SetToastMessage(TempMessageKeys.TEMP_MESSAGE_KEY_PLAYER_INVITED,$"Mail to invite {playerInvitationViewModel.PlayerName} sended succesfully");
+            SetToastMessage(TempMessageKeys.TEMP_MESSAGE_KEY_PLAYER_INVITED,$"Email invitation successfully sent to {playerInvitationViewModel.PlayerName}!");
 
             return new RedirectResult(Url.Action(MVC.GamingGroup.ActionNames.Index, MVC.GamingGroup.Name));
         }

--- a/Source/UI/UI.csproj
+++ b/Source/UI/UI.csproj
@@ -161,9 +161,8 @@
     <Reference Include="Mvc.RazorTools">
       <HintPath>..\..\packages\Mvc.RazorTools.Base.1.0.5\lib\net45\Mvc.RazorTools.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
@@ -172,17 +171,11 @@
       <HintPath>..\..\packages\RollbarSharp.0.3.5.0\lib\net40\RollbarSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SendGrid, Version=6.3.0.0, Culture=neutral, PublicKeyToken=4f047e93159395ca, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Sendgrid.6.3.0\lib\SendGrid.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SendGrid, Version=9.8.0.0, Culture=neutral, PublicKeyToken=4f047e93159395ca, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Sendgrid.9.9.0\lib\net452\SendGrid.dll</HintPath>
     </Reference>
-    <Reference Include="SendGrid.SmtpApi, Version=1.3.1.0, Culture=neutral, PublicKeyToken=2ae73662c35d80e4, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SendGrid.SmtpApi.1.3.1\lib\net40\SendGrid.SmtpApi.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="SendGridMail, Version=6.3.0.0, Culture=neutral, PublicKeyToken=4f047e93159395ca, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Sendgrid.6.3.0\lib\SendGridMail.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SendGrid.SmtpApi, Version=1.3.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SendGrid.SmtpApi.1.3.3\lib\SendGrid.SmtpApi.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap, Version=4.4.2.472, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\StructureMap.4.4.2\lib\net45\StructureMap.dll</HintPath>

--- a/Source/UI/Web.config
+++ b/Source/UI/Web.config
@@ -18,6 +18,7 @@
     <add key="currentApiVersion" value="2" />
     <add key="sitemapLocationFilePath" value="C:\temp\nemestats\sitemaps\" />
     <add key="sitemapLocationHttpPath" value="http://localhost:44300/sitemaps/" />
+    <!--Developer key with minor send capabilities -->
     <add key="sendgridApiKey" value="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" />
   </appSettings>
   

--- a/Source/UI/Web.config
+++ b/Source/UI/Web.config
@@ -18,6 +18,7 @@
     <add key="currentApiVersion" value="2" />
     <add key="sitemapLocationFilePath" value="C:\temp\nemestats\sitemaps\" />
     <add key="sitemapLocationHttpPath" value="http://localhost:44300/sitemaps/" />
+    <add key="sendgridApiKey" value="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" />
   </appSettings>
   
   <!--Need to prevent API errors from getting intercepted by <httpErrors> section handling.-->
@@ -111,7 +112,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Source/UI/packages.config
+++ b/Source/UI/packages.config
@@ -49,15 +49,16 @@
   <package id="Modernizr" version="2.8.3" targetFramework="net45" />
   <package id="Moment.js" version="2.11.1" targetFramework="net452" />
   <package id="Mvc.RazorTools.Base" version="1.0.5" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Respond" version="1.4.2" targetFramework="net45" />
   <package id="RollbarSharp" version="0.3.5.0" targetFramework="net452" />
-  <package id="Sendgrid" version="6.3.0" targetFramework="net45" />
-  <package id="SendGrid.SmtpApi" version="1.3.1" targetFramework="net45" />
+  <package id="Sendgrid" version="9.9.0" targetFramework="net452" />
+  <package id="SendGrid.SmtpApi" version="1.3.3" targetFramework="net452" />
   <package id="StructureMap" version="4.4.2" targetFramework="net452" />
   <package id="structuremap.web" version="4.0.0.315" targetFramework="net45" />
   <package id="System.Configuration.Abstractions" version="2.0.2.26" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.0.0" targetFramework="net452" />
   <package id="T4MVC" version="3.16.5" targetFramework="net45" />
   <package id="T4MVCExtensions" version="3.16.5" targetFramework="net45" />
   <package id="Twitter.Bootstrap.Sass" version="3.3.7" targetFramework="net452" />

--- a/Tests/BoardGameGeekApiClient.Tests/App.config
+++ b/Tests/BoardGameGeekApiClient.Tests/App.config
@@ -20,7 +20,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Tests/BoardGameGeekApiClient.Tests/BoardGameGeekApiClient.Tests.csproj
+++ b/Tests/BoardGameGeekApiClient.Tests/BoardGameGeekApiClient.Tests.csproj
@@ -58,9 +58,8 @@
       <HintPath>..\..\packages\NUnit3TestAdapter.3.4.0\lib\Mono.Cecil.Rocks.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>

--- a/Tests/BoardGameGeekApiClient.Tests/packages.config
+++ b/Tests/BoardGameGeekApiClient.Tests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Bcl" version="1.1.8" targetFramework="net452" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NUnit" version="3.6.0" targetFramework="net452" />
   <package id="NUnit3TestAdapter" version="3.4.0" targetFramework="net452" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net452" />

--- a/Tests/BusinessLogic.Tests/App.config
+++ b/Tests/BusinessLogic.Tests/App.config
@@ -33,7 +33,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Tests/BusinessLogic.Tests/BusinessLogic.Tests.csproj
+++ b/Tests/BusinessLogic.Tests/BusinessLogic.Tests.csproj
@@ -112,9 +112,8 @@
       <HintPath>..\..\packages\NUnit3TestAdapter.3.4.0\lib\Mono.Cecil.Rocks.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>

--- a/Tests/BusinessLogic.Tests/UnitTests/LogicTests/PlayersTests/PlayerSaverTests/CreatePlayerTests.cs
+++ b/Tests/BusinessLogic.Tests/UnitTests/LogicTests/PlayersTests/PlayerSaverTests/CreatePlayerTests.cs
@@ -96,6 +96,8 @@ namespace BusinessLogic.Tests.UnitTests.LogicTests.PlayersTests.PlayerSaverTests
 
             //--assert
             actualException.Message.ShouldBe(expectedException.Message);
+            //--this is the 2nd 409 conflict from this operation
+            actualException.ErrorSubCode.ShouldBe(2);
         }
 
         [Test]

--- a/Tests/BusinessLogic.Tests/UnitTests/LogicTests/PlayersTests/PlayerSaverTests/CreatePlayerTests.cs
+++ b/Tests/BusinessLogic.Tests/UnitTests/LogicTests/PlayersTests/PlayerSaverTests/CreatePlayerTests.cs
@@ -8,6 +8,7 @@ using BusinessLogic.Models.Players;
 using BusinessLogic.Models.User;
 using NUnit.Framework;
 using Rhino.Mocks;
+using Shouldly;
 
 namespace BusinessLogic.Tests.UnitTests.LogicTests.PlayersTests.PlayerSaverTests
 {
@@ -55,6 +56,20 @@ namespace BusinessLogic.Tests.UnitTests.LogicTests.PlayersTests.PlayerSaverTests
             var actualException = Assert.Throws<UserHasNoGamingGroupException>(() => _autoMocker.ClassUnderTest.CreatePlayer(_createPlayerRequest, _currentUser));
 
             Assert.AreEqual(expectedException.Message, actualException.Message);
+        }
+
+        [Test]
+        public void ItThrowsAPlayerWithThisEmailAlreadyExistsExceptionIfAPlayerAlreadyHasTheSpecifiedEmailInTheGamingGroup()
+        {
+            //--arrange
+            _createPlayerRequest.PlayerEmailAddress = _playerWithRegisteredUser.User.Email;
+            var expectedException = new PlayerWithThisEmailAlreadyExistsException(_createPlayerRequest.PlayerEmailAddress, _playerWithRegisteredUser.Name, _playerWithRegisteredUser.Id);
+
+            //--act
+            var actualException = Assert.Throws<PlayerWithThisEmailAlreadyExistsException>(() => _autoMocker.ClassUnderTest.CreatePlayer(_createPlayerRequest, _currentUser));
+
+            //--assert
+            actualException.Message.ShouldBe(expectedException.Message);
         }
 
         [Test]

--- a/Tests/BusinessLogic.Tests/UnitTests/LogicTests/PlayersTests/PlayerSaverTests/CreatePlayerTests.cs
+++ b/Tests/BusinessLogic.Tests/UnitTests/LogicTests/PlayersTests/PlayerSaverTests/CreatePlayerTests.cs
@@ -96,8 +96,6 @@ namespace BusinessLogic.Tests.UnitTests.LogicTests.PlayersTests.PlayerSaverTests
 
             //--assert
             actualException.Message.ShouldBe(expectedException.Message);
-            //--this is the 2nd 409 conflict from this operation
-            actualException.ErrorSubCode.ShouldBe(2);
         }
 
         [Test]

--- a/Tests/BusinessLogic.Tests/UnitTests/LogicTests/PlayersTests/PlayerSaverTests/CreatePlayerTests.cs
+++ b/Tests/BusinessLogic.Tests/UnitTests/LogicTests/PlayersTests/PlayerSaverTests/CreatePlayerTests.cs
@@ -59,6 +59,20 @@ namespace BusinessLogic.Tests.UnitTests.LogicTests.PlayersTests.PlayerSaverTests
         }
 
         [Test]
+        public void ItThrowsAnArgumentExceptionIfBothAnEmailAddressIsEnteredAndTheFlagIsSetToAssociateThePlayerWithTheCurrentUser()
+        {
+            //--arrange
+            _createPlayerRequest.PlayerEmailAddress = "some email";
+            var expectedException = new ArgumentException("You cannot specify an email address for the new Player while simultaneously requesting to associate the Player with the current user.");
+
+            //--act
+            var actualException = Assert.Throws<ArgumentException>(() => _autoMocker.ClassUnderTest.CreatePlayer(_createPlayerRequest, _currentUser, true));
+
+            //--assert
+            actualException.Message.ShouldBe(expectedException.Message);
+        }
+
+        [Test]
         public void ItThrowsAPlayerWithThisEmailAlreadyExistsExceptionIfAPlayerAlreadyHasTheSpecifiedEmailInTheGamingGroup()
         {
             //--arrange

--- a/Tests/BusinessLogic.Tests/UnitTests/LogicTests/PlayersTests/PlayerSaverTests/PlayerSaverTestBase.cs
+++ b/Tests/BusinessLogic.Tests/UnitTests/LogicTests/PlayersTests/PlayerSaverTests/PlayerSaverTestBase.cs
@@ -16,6 +16,8 @@ namespace BusinessLogic.Tests.UnitTests.LogicTests.PlayersTests.PlayerSaverTests
         protected ApplicationUser _currentUser;
         protected List<Player> _players;
         protected Player _playerThatAlreadyExists;
+        protected Player _playerWithRegisteredUser;
+
         protected int _idOfPlayerThatAlreadyExists;
 
         [SetUp]
@@ -36,9 +38,21 @@ namespace BusinessLogic.Tests.UnitTests.LogicTests.PlayersTests.PlayerSaverTests
                 Name = "name of existing player",
                 GamingGroupId = _currentUser.CurrentGamingGroupId.Value
             };
+            _playerWithRegisteredUser = new Player
+            {
+                Name = "player with existing registered user",
+                Id = 55,
+                GamingGroupId = _currentUser.CurrentGamingGroupId.Value,
+                ApplicationUserId = "some value",
+                User = new ApplicationUser
+                {
+                    Email = "some email address",
+                }
+            };
             _players = new List<Player>
             {
                 _playerThatAlreadyExists,
+                _playerWithRegisteredUser,
                 new Player
                 {
                     Id = 2

--- a/Tests/BusinessLogic.Tests/packages.config
+++ b/Tests/BusinessLogic.Tests/packages.config
@@ -15,7 +15,7 @@
   <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security.Cookies" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security.OAuth" version="3.0.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net452" />
   <package id="NSubstituteAutoMocker" version="1.1.0.0" targetFramework="net452" />
   <package id="NUnit" version="3.6.0" targetFramework="net452" />

--- a/Tests/NemeStats.ScheduledJobs.Tests/NemeStats.ScheduledJobs.Tests/NemeStats.ScheduledJobs.Tests.csproj
+++ b/Tests/NemeStats.ScheduledJobs.Tests/NemeStats.ScheduledJobs.Tests/NemeStats.ScheduledJobs.Tests.csproj
@@ -70,9 +70,8 @@
       <HintPath>..\..\..\packages\ncrontab.2.0.0\lib\net20\NCrontab.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>

--- a/Tests/NemeStats.ScheduledJobs.Tests/NemeStats.ScheduledJobs.Tests/app.config
+++ b/Tests/NemeStats.ScheduledJobs.Tests/NemeStats.ScheduledJobs.Tests/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Tests/NemeStats.ScheduledJobs.Tests/NemeStats.ScheduledJobs.Tests/packages.config
+++ b/Tests/NemeStats.ScheduledJobs.Tests/NemeStats.ScheduledJobs.Tests/packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="ncrontab" version="2.0.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net452" />
   <package id="NSubstituteAutoMocker" version="1.1.0.0" targetFramework="net452" />
   <package id="NUnit" version="3.6.0" targetFramework="net452" />

--- a/Tests/UI.Tests/App.config
+++ b/Tests/UI.Tests/App.config
@@ -35,7 +35,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Tests/UI.Tests/UI.Tests.csproj
+++ b/Tests/UI.Tests/UI.Tests.csproj
@@ -116,9 +116,8 @@
       <HintPath>..\..\packages\NUnit3TestAdapter.3.4.0\lib\Mono.Cecil.Rocks.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>

--- a/Tests/UI.Tests/UnitTests/AreasTests/ApiTests/ControllersTests/PlayersControllerTests/SaveNewPlayerTests.cs
+++ b/Tests/UI.Tests/UnitTests/AreasTests/ApiTests/ControllersTests/PlayersControllerTests/SaveNewPlayerTests.cs
@@ -3,8 +3,10 @@ using BusinessLogic.Logic.Players;
 using BusinessLogic.Models;
 using BusinessLogic.Models.Players;
 using BusinessLogic.Models.User;
+using NemeStats.TestingHelpers.NemeStatsTestingExtensions;
 using NUnit.Framework;
 using Rhino.Mocks;
+using Shouldly;
 using UI.Areas.Api.Controllers;
 using UI.Areas.Api.Models;
 
@@ -36,16 +38,19 @@ namespace UI.Tests.UnitTests.AreasTests.ApiTests.ControllersTests.PlayersControl
             var newPlayerMessage = new NewPlayerMessage
             {
                 PlayerName = "some player name",
-                GamingGroupId = _expectedGamingGroupId
+                GamingGroupId = _expectedGamingGroupId,
+                PlayerEmailAddress = "some email address"
             };
 
             _autoMocker.ClassUnderTest.SaveNewPlayer(newPlayerMessage, _expectedGamingGroupId);
 
-            _autoMocker.Get<IPlayerSaver>().AssertWasCalled(
-                mock => mock.CreatePlayer(Arg<CreatePlayerRequest>.Matches(player => player.Name == newPlayerMessage.PlayerName
-                && player.GamingGroupId == _expectedGamingGroupId),
-                    Arg<ApplicationUser>.Is.Anything,
-                    Arg<bool>.Is.Equal(false)));
+            var args = _autoMocker.Get<IPlayerSaver>().GetArgumentsForCallsMadeOn(
+                mock => mock.CreatePlayer(Arg<CreatePlayerRequest>.Is.Anything, Arg<ApplicationUser>.Is.Anything,
+                    Arg<bool>.Is.Anything));
+            var firstCall = args.AssertFirstCallIsType<CreatePlayerRequest>();
+            firstCall.Name.ShouldBe(newPlayerMessage.PlayerName);
+            firstCall.GamingGroupId.ShouldBe(newPlayerMessage.GamingGroupId);
+            firstCall.PlayerEmailAddress.ShouldBe(newPlayerMessage.PlayerEmailAddress);
         }
 
         [Test]

--- a/Tests/UI.Tests/UnitTests/ControllerTests/PlayerControllerTests/InvitePlayerHttpPostTests.cs
+++ b/Tests/UI.Tests/UnitTests/ControllerTests/PlayerControllerTests/InvitePlayerHttpPostTests.cs
@@ -16,14 +16,12 @@
 //     along with this program.  If not, see <http://www.gnu.org/licenses/>
 #endregion
 
-using System.Linq;
 using BusinessLogic.Models.Players;
 using BusinessLogic.Models.User;
 using NUnit.Framework;
 using Rhino.Mocks;
 using UI.Models.Players;
 using BusinessLogic.Logic.Players;
-using System.Web.Mvc;
 
 namespace UI.Tests.UnitTests.ControllerTests.PlayerControllerTests
 {

--- a/Tests/UI.Tests/packages.config
+++ b/Tests/UI.Tests/packages.config
@@ -19,7 +19,7 @@
   <package id="Microsoft.Owin.Security.Cookies" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security.OAuth" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NUnit" version="3.6.0" targetFramework="net452" />
   <package id="NUnit3TestAdapter" version="3.4.0" targetFramework="net452" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
* The POST /Players endpoint can now accept an email address so you can send an invitation at the same time as creating the Player
* Added errorSubCode to the endpoint so you can distinguish between two different 409 conflicts (player name exists, and email already taken) without having to rely on the message
* Upgraded SendGrid to version 9 which now uses an API key
* Tweaked player invitation email content slightly